### PR TITLE
Prefix the plugin folder with the namespace

### DIFF
--- a/lib/init-wp-scripts.js
+++ b/lib/init-wp-scripts.js
@@ -9,10 +9,8 @@ const { join } = require( 'path' );
  */
 const { info } = require( './log' );
 
-module.exports = async function( {
-	slug,
-} ) {
-	const cwd = join( process.cwd(), slug );
+module.exports = async function( folderName ) {
+	const cwd = join( process.cwd(), folderName );
 
 	info( '' );
 	info( 'Installing packages. It might take a couple of minutes.' );

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -30,14 +30,14 @@ module.exports = async function(
 		version,
 	}
 ) {
-	info( '' );
-	info( `Creating a new WordPress block in "${ slug }" folder.` );
 
-	const view = {
+	const namespaceToLower = toLower( namespace );
+	const folderName       = `${ namespaceToLower }-${ slug }`;
+	const view             = {
 		namespace,
 		namespaceSnakeCase: snakeCase( namespace ),
 		namespaceKebabCase: kebabCase( namespace ),
-		namespaceToLower: toLower( namespace ),
+		namespaceToLower,
 		fullNamespace: `${ namespace }\\${ blockName }`,
 		slug,
 		slugSnakeCase: snakeCase( slug ),
@@ -51,6 +51,10 @@ module.exports = async function(
 		licenseURI,
 		textdomain: slug,
 	};
+
+	info( '' );
+	info( `Creating a new WordPress block in "${ folderName }" folder.` );
+
 	await Promise.all(
 		getOutputFiles( templateName ).map( async ( file ) => {
 			const template = await readFile(
@@ -61,7 +65,7 @@ module.exports = async function(
 				'utf8'
 			);
 			// Output files can have names that depend on the slug provided.
-			const outputFilePath = `${ slug }/${ file.replace(
+			const outputFilePath = `${ folderName }/${ file.replace(
 				/\$slug|\$demo/g,
 				slug
 			) }`;
@@ -70,11 +74,11 @@ module.exports = async function(
 		} )
 	);
 
-	await initWPScripts( view );
+	await initWPScripts( folderName );
 
 	info( '' );
 	success(
-		`Done: block "${ title }" bootstrapped in the "${ slug }" folder.`
+		`Done: block "${ title }" bootstrapped in the "${ folderName }" folder.`
 	);
 	info( '' );
 	info( 'Inside that directory, you can run several commands:' );
@@ -99,7 +103,7 @@ module.exports = async function(
 	info( '' );
 	info( 'You can start by typing:' );
 	info( '' );
-	code( `  $ cd ${ slug }` );
+	code( `  $ cd ${ folderName }` );
 	code( `  $ npm start` );
 	info( '' );
 	info( 'Code is Poetry' );


### PR DESCRIPTION
Closes #15.

### DESCRIPTION ###

**Problem**

WordPress uses `plugin-folder-name/plugin.php` to check if a new update is present for that plugin is available in [WP.org's public plugin repo](https://wordpress.org/plugins/). So if we scaffold a new plugin with the same `plugin-folder-name/plugin.php` structure, it will assume that the scaffolded plugin is a plugin from the public plugin repo.

**Solution** 

This PR will append the <NAMESPACE> provided by the user as the plugin folder. So the scaffolded plugin will have the structure `namespace-slug/slug.php`. This will diminish the probability of plugin conflict with WP.org's public plugin repo.

Examples.

```
// The scaffolded plugin folder is `webdevstudios-todo-list`. Before this PR, the plugin folder is `todo-list`.
$ npm init @webdevstudios/block WebDevStudios/TodoList

// The scaffolded plugin folder is `donmhico-lorem-ipsum-block`. Before, the plugin folder is `lorem-ipsum-block`
$ npm init @webdevstudios/block DonMhico/LoremIpsumBlock
```

### SCREENSHOTS ###
1. Plugins scaffolded.
![Screen Shot 2020-06-30 at 11 57 47 PM](https://user-images.githubusercontent.com/5747475/86148820-aedf1780-bb2d-11ea-9913-303e0b90435e.png)
1. Dashboard > Plugins view
![Screen Shot 2020-06-30 at 11 59 45 PM](https://user-images.githubusercontent.com/5747475/86148979-ec43a500-bb2d-11ea-984e-685db2a5cfbc.png)

### STEPS TO VERIFY ###

Follow [Using or Testing a Branch](https://github.com/WebDevStudios/create-block/wiki/Using-or-Testing-a-branch) to test this PR's branch.
