### PR TITLE
Issue/17 better interactive support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,8 @@ program
 				const answers = {
 					...defaultValues,
 					author: blockNameArr[0],
-					blockName: blockNameArr[1],
 					namespace: blockNameArr[0],
-					slug: kebabCase( blockNameArr[1] ),
+					slug: blockNameArr[1],
 					title: `${ blockNameArr[0] } ${ startCase( blockNameArr[1] ) }`,
 				};
 				await scaffold( template, answers );

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-const { isEmpty, upperFirst } = require( 'lodash' );
+const { isEmpty, upperFirst, kebabCase } = require( 'lodash' );
 
 const slug = {
 	type: 'input',
 	name: 'slug',
 	message:
-		'The block slug used for identification (also the plugin and output folder name):',
+		'The plugin and block name (in PascalCase):',
 	validate( input ) {
-		if ( ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
-			return 'Invalid block slug specified. Block slug can contain only lowercase alphanumeric characters or dashes, and start with a letter.';
+		if ( ! /^[A-Z][a-zA-Z0-9]*$/.test( input ) ) {
+			return 'Invalid block name specified. Block name can contain only alphanumeric characters, start with a letter, and in PascalCase.';
 		}
 
 		return true;
@@ -23,8 +23,8 @@ const namespace = {
 	message:
 		'The internal namespace for the block name (something unique for your products):',
 	validate( input ) {
-		if ( ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
-			return 'Invalid block namespace specified. Block namespace can contain only lowercase alphanumeric characters or dashes, and start with a letter.';
+		if ( ! /^[A-Z][a-zA-Z0-9]*$/.test( input ) ) {
+			return 'Invalid namespace specified. Namespace can contain only alphanumeric characters, start with a letter, and in PascalCase.';
 		}
 
 		return true;

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -18,7 +18,6 @@ module.exports = async function(
 	templateName,
 	{
 		namespace,
-		blockName,
 		slug,
 		title,
 		description,
@@ -30,17 +29,18 @@ module.exports = async function(
 		version,
 	}
 ) {
-
+	const slugKebabCase    = kebabCase( slug );
 	const namespaceToLower = toLower( namespace );
-	const folderName       = `${ namespaceToLower }-${ slug }`;
+	const folderName       = `${ namespaceToLower }-${ slugKebabCase }`;
 	const view             = {
 		namespace,
 		namespaceSnakeCase: snakeCase( namespace ),
 		namespaceKebabCase: kebabCase( namespace ),
 		namespaceToLower,
-		fullNamespace: `${ namespace }\\${ blockName }`,
+		fullNamespace: `${ namespace }\\${ slug }`,
 		slug,
 		slugSnakeCase: snakeCase( slug ),
+		slugKebabCase,
 		title,
 		description,
 		dashicon,
@@ -49,7 +49,7 @@ module.exports = async function(
 		author,
 		license,
 		licenseURI,
-		textdomain: slug,
+		textdomain: slugKebabCase,
 	};
 
 	info( '' );
@@ -67,7 +67,7 @@ module.exports = async function(
 			// Output files can have names that depend on the slug provided.
 			const outputFilePath = `${ folderName }/${ file.replace(
 				/\$slug|\$demo/g,
-				slug
+				slugKebabCase
 			) }`;
 			await makeDir( dirname( outputFilePath ) );
 			writeFile( outputFilePath, render( template, view ) );

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -29,15 +29,17 @@ module.exports = async function(
 		version,
 	}
 ) {
-	const slugKebabCase    = kebabCase( slug );
-	const namespaceToLower = toLower( namespace );
-	const folderName       = `${ namespaceToLower }-${ slugKebabCase }`;
-	const view             = {
+	const slugKebabCase      = kebabCase( slug );
+	const namespaceKebabCase = kebabCase( namespace );
+	const namespaceToLower   = toLower( namespace );
+	const folderName         = `${ namespaceToLower }-${ slugKebabCase }`;
+	const view               = {
 		namespace,
 		namespaceSnakeCase: snakeCase( namespace ),
-		namespaceKebabCase: kebabCase( namespace ),
+		namespaceKebabCase: namespaceKebabCase,
 		namespaceToLower,
 		fullNamespace: `${ namespace }\\${ slug }`,
+		fullNamespaceKebabCase: `${ namespaceKebabCase }-${ slugKebabCase }`,
 		slug,
 		slugSnakeCase: snakeCase( slug ),
 		slugKebabCase,

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -15,8 +15,8 @@ const version = '0.1.0';
 const templates = {
     wds: {
         defaultValues: {
-            namespace,
-            slug: 'wds-block-starter',
+            namespace: 'WebDevStudios',
+            slug: 'BlockStarter',
             title: 'WDS Block Starter',
             description:
                 'A starter plugin for Gutenberg blocks development.',

--- a/lib/templates/wds/$slug.php.mustache
+++ b/lib/templates/wds/$slug.php.mustache
@@ -40,7 +40,7 @@ function register_block() {
 
 	// Verify we have an editor script.
 	if ( ! file_exists( plugin_dir_path( __FILE__ ) . $editor_script ) ) {
-		wp_die( esc_html__( 'Whoops! You need to run `npm run build` for the {{ title }} first.', '{{ slug }}' ) );
+		wp_die( esc_html__( 'Whoops! You need to run `npm run build` for the {{ title }} first.', '{{ textdomain }}' ) );
 	}
 
 	// Autoload dependencies and version.
@@ -48,7 +48,7 @@ function register_block() {
 
 	// Register editor script.
 	wp_register_script(
-		'{{ slug }}-editor-script',
+		'{{ slugKebabCase }}-editor-script',
 		plugins_url( $editor_script, __FILE__ ),
 		$asset_file['dependencies'],
 		$asset_file['version'],
@@ -58,7 +58,7 @@ function register_block() {
 	// Register editor style.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $editor_style ) ) {
 		wp_register_style(
-			'{{ slug }}-editor-style',
+			'{{ slugKebabCase }}-editor-style',
 			plugins_url( $editor_style, __FILE__ ),
 			[ 'wp-edit-blocks' ],
 			filemtime( plugin_dir_path( __FILE__ ) . $editor_style )
@@ -68,7 +68,7 @@ function register_block() {
 	// Register frontend style.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $frontend_style ) ) {
 		wp_register_style(
-			'{{ slug }}-style',
+			'{{ slugKebabCase }}-style',
 			plugins_url( $frontend_style, __FILE__ ),
 			[],
 			filemtime( plugin_dir_path( __FILE__ ) . $frontend_style )
@@ -76,16 +76,16 @@ function register_block() {
 	}
 
 	// Register block with WordPress.
-	register_block_type( '{{ namespaceKebabCase }}/{{ slug }}', array(
-		'editor_script' => '{{ slug }}-editor-script',
-		'editor_style'  => '{{ slug }}-editor-style',
-		'style'         => '{{ slug }}-style',
+	register_block_type( '{{ namespaceKebabCase }}/{{ slugKebabCase }}', array(
+		'editor_script' => '{{ slugKebabCase }}-editor-script',
+		'editor_style'  => '{{ slugKebabCase }}-editor-style',
+		'style'         => '{{ slugKebabCase }}-style',
 	) );
 
 	// Register frontend script.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $frontend_script ) ) {
 		wp_enqueue_script(
-			'{{ slug }}-frontend-script',
+			'{{ slugKebabCase }}-frontend-script',
 			plugins_url( $frontend_script, __FILE__ ),
 			$asset_file['dependencies'],
 			$asset_file['version'],

--- a/lib/templates/wds/$slug.php.mustache
+++ b/lib/templates/wds/$slug.php.mustache
@@ -48,7 +48,7 @@ function register_block() {
 
 	// Register editor script.
 	wp_register_script(
-		'{{ slugKebabCase }}-editor-script',
+		'{{ fullNamespaceKebabCase }}-editor-script',
 		plugins_url( $editor_script, __FILE__ ),
 		$asset_file['dependencies'],
 		$asset_file['version'],
@@ -58,7 +58,7 @@ function register_block() {
 	// Register editor style.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $editor_style ) ) {
 		wp_register_style(
-			'{{ slugKebabCase }}-editor-style',
+			'{{ fullNamespaceKebabCase }}-editor-style',
 			plugins_url( $editor_style, __FILE__ ),
 			[ 'wp-edit-blocks' ],
 			filemtime( plugin_dir_path( __FILE__ ) . $editor_style )
@@ -68,7 +68,7 @@ function register_block() {
 	// Register frontend style.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $frontend_style ) ) {
 		wp_register_style(
-			'{{ slugKebabCase }}-style',
+			'{{ fullNamespaceKebabCase }}-style',
 			plugins_url( $frontend_style, __FILE__ ),
 			[],
 			filemtime( plugin_dir_path( __FILE__ ) . $frontend_style )
@@ -77,15 +77,15 @@ function register_block() {
 
 	// Register block with WordPress.
 	register_block_type( '{{ namespaceKebabCase }}/{{ slugKebabCase }}', array(
-		'editor_script' => '{{ slugKebabCase }}-editor-script',
-		'editor_style'  => '{{ slugKebabCase }}-editor-style',
-		'style'         => '{{ slugKebabCase }}-style',
+		'editor_script' => '{{ fullNamespaceKebabCase }}-editor-script',
+		'editor_style'  => '{{ fullNamespaceKebabCase }}-editor-style',
+		'style'         => '{{ fullNamespaceKebabCase }}-style',
 	) );
 
 	// Register frontend script.
 	if ( file_exists( plugin_dir_path( __FILE__ ) . $frontend_script ) ) {
 		wp_enqueue_script(
-			'{{ slugKebabCase }}-frontend-script',
+			'{{ fullNamespaceKebabCase }}-frontend-script',
 			plugins_url( $frontend_script, __FILE__ ),
 			$asset_file['dependencies'],
 			$asset_file['version'],

--- a/lib/templates/wds/composer.json.mustache
+++ b/lib/templates/wds/composer.json.mustache
@@ -1,5 +1,5 @@
 {
-  "name": "{{ namespaceToLower }}/{{ slug }}",
+  "name": "{{ namespaceKebabCase }}/{{ slugKebabCase }}",
   "description": "A block starter for WebDevStudios projects.",
   "type": "wordpress-plugin",
   "authors": [

--- a/lib/templates/wds/src/block/$demo/editor.scss.mustache
+++ b/lib/templates/wds/src/block/$demo/editor.scss.mustache
@@ -1,6 +1,6 @@
 // WordPress editor styles
 $color-blue: rgb(33, 175, 194);
 
-.wp-block-{{ namespaceKebabCase }}-{{ slug }} {
+.wp-block-{{ namespaceKebabCase }}-{{ slugKebabCase }} {
 	color: $color-blue;
 }

--- a/lib/templates/wds/src/block/$demo/index.js.mustache
+++ b/lib/templates/wds/src/block/$demo/index.js.mustache
@@ -7,7 +7,7 @@ import save from './save';
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
-registerBlockType( '{{ namespaceKebabCase }}/{{ slug }}', {
+registerBlockType( '{{ namespaceKebabCase }}/{{ slugKebabCase }}', {
 	title: __( '{{ title }}', '{{ textdomain }}' ),
 	icon: 'edit',
 	category: 'common',

--- a/lib/templates/wds/src/block/$demo/style.scss.mustache
+++ b/lib/templates/wds/src/block/$demo/style.scss.mustache
@@ -1,6 +1,6 @@
 // Front-end styles
 $color-red: rgb(206, 70, 70);
 
-.wp-block-{{ namespaceKebabCase }}-{{ slug }} {
+.wp-block-{{ namespaceKebabCase }}-{{ slugKebabCase }} {
 	color: $color-red;
 }

--- a/lib/templates/wds/src/block/index.js.mustache
+++ b/lib/templates/wds/src/block/index.js.mustache
@@ -1,1 +1,1 @@
-import './{{ slug }}';
+import './{{ slugKebabCase }}';


### PR DESCRIPTION
Linked Issue: https://github.com/WebDevStudios/create-block/issues/17

### DESCRIPTION ###
Improves and fixes some issues when using the interactive console.

**Notable Changes**
Before only the block name is used in `$handle` in both `wp_register_script()` and `wp_register_style()` which could introduce potential conflicts with other blocks scaffolded using this tool. This PR includes a patch which use the namespace + block name in `$handle`.

### SCREENSHOTS ###
1. Using the interactive console.
<img width="1572" alt="1" src="https://user-images.githubusercontent.com/5747475/87670630-a24ff580-c7a2-11ea-97ff-cc6a0d5480b2.png">

2. Plugin info header. As 
<img width="882" alt="2" src="https://user-images.githubusercontent.com/5747475/87670949-2609e200-c7a3-11ea-95bf-0978267740a4.png">

3. Block in action
<img width="1398" alt="3" src="https://user-images.githubusercontent.com/5747475/87671776-80577280-c7a4-11ea-8e55-8bff570c7324.png">

<img width="1680" alt="4" src="https://user-images.githubusercontent.com/5747475/87672082-f5c34300-c7a4-11ea-87ed-f1080a6b1399.png">

<img width="1680" alt="5" src="https://user-images.githubusercontent.com/5747475/87672151-0e335d80-c7a5-11ea-8241-8cda296d5f04.png">

### STEPS TO VERIFY ###
1. Read the wiki to test this PR's branch - https://github.com/WebDevStudios/create-block/wiki/Using-or-Testing-a-branch
2. Run `npm run create-block` (without passing the namespace and block name) to initiate the interactive console.
3. Complete the interactive console and wait for the block plugin to be generated,
