### PR TITLE
Prevent overriding existing plugin

### DIFF
--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -4,6 +4,7 @@
 const { dirname, join } = require( 'path' );
 const makeDir = require( 'make-dir' );
 const { readFile, writeFile } = require( 'fs' ).promises;
+const { existsSync } = require( 'fs' );
 const { render } = require( 'mustache' );
 const { snakeCase, kebabCase, toLower } = require( 'lodash' );
 
@@ -11,7 +12,7 @@ const { snakeCase, kebabCase, toLower } = require( 'lodash' );
  * Internal dependencies
  */
 const initWPScripts = require( './init-wp-scripts' );
-const { code, info, success } = require( './log' );
+const { code, info, success, error } = require( './log' );
 const { getOutputFiles } = require( './templates' );
 
 module.exports = async function(
@@ -55,6 +56,13 @@ module.exports = async function(
 	};
 
 	info( '' );
+
+	// Check if plugin / folder already exists.
+	if ( existsSync( `./${ folderName }` ) ) {
+		error( `${ folderName } folder already exists.` );
+		process.exit( 1 );
+	}
+
 	info( `Creating a new WordPress block in "${ folderName }" folder.` );
 
 	await Promise.all(


### PR DESCRIPTION
### DESCRIPTION ###
From #17, @bobbingwide mentioned that our scaffolding tool overwrites an existing plugin without any warning. This could easily break existing environment if a working plugin was suddenly overwritten. This PR will prevent this behavior and shows an error instead.

### SCREENSHOTS ###
1. Encircled previously generated plugins.
<img width="1213" alt="Screen Shot 2020-07-17 at 1 17 03 AM" src="https://user-images.githubusercontent.com/5747475/87702023-6d0bcd80-c7cb-11ea-8bc4-d1e1cd2b1d3d.png">

2. Try to scaffold an existing plugin and seeing the error.
<img width="1219" alt="Screen Shot 2020-07-17 at 1 18 52 AM" src="https://user-images.githubusercontent.com/5747475/87702156-9fb5c600-c7cb-11ea-901a-70b8921ac7dc.png">

### STEPS TO VERIFY ###
1. Follow this wiki to test this PR's branch - https://github.com/WebDevStudios/create-block/wiki/Using-or-Testing-a-branch
1. Scaffold a plugin and wait for it end successfully.
1. Try to scaffold again the same plugin. You should see the error.
